### PR TITLE
feat(format): support custom date formats via `-f, --format` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ $ matter-now
 Usage: matter-now <file...>
 
 Options:
-  -v, --version  output the version number
-  -h, --help     output usage information
+  -f, --format <format>  Moment.js date format
+  -v, --version          output the version number
+  -h, --help             display help for command
 ```
 
 matter-now can also be used with [lint-staged](https://github.com/okonet/lint-staged) to append dates to git staged Markdown files:

--- a/bin/matter-now
+++ b/bin/matter-now
@@ -5,8 +5,9 @@ const { version } = require('../package.json');
 const matterNow = require('..');
 
 program
-  .version(version, '-v, --version')
   .usage('<file...>')
+  .option('-f, --format <format>', 'Moment.js date format')
+  .version(version, '-v, --version')
   .parse(process.argv);
 
 const files = program.args;

--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@ const moment = require('moment');
 const hasMatter = (matter) => matter.isEmpty || Object.keys(matter.data).length > 0;
 const hasDate = (matter) => 'date' in matter.data;
 
-module.exports = (files) => files.forEach((file) => {
+module.exports = (files, { format }) => files.forEach((file) => {
   const matter = grayMatter.read(file, {});
 
   if (!hasMatter(matter) || hasDate(matter)) {
     return;
   }
 
-  const date = moment().format();
+  const date = moment().format(format);
   const newMatter = `${matter.matter}\ndate: ${date}`;
   const newData = `---${newMatter}\n---\n${matter.content}`;
 


### PR DESCRIPTION
Allow defining custom [Moment.js date formats](https://momentjs.com/docs/#/displaying/format/) via a `-f, --format` option.

Closes #1.