### PR TITLE
feat(attr): support custom front matter attributes via `-a, --attr` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ $ matter-now
 Usage: matter-now [options] <file...>
 
 Options:
-  -f, --format <format>  Moment.js date format
-  -v, --version          output the version number
-  -h, --help             display help for command
+  -a, --attr <attribute>  front matter attribute (default: "date")
+  -f, --format <format>   Moment.js date format
+  -v, --version           output the version number
+  -h, --help              display help for command
 ```
 
 matter-now can also be used with [lint-staged](https://github.com/okonet/lint-staged) to append dates to git staged Markdown files:

--- a/bin/matter-now
+++ b/bin/matter-now
@@ -6,6 +6,7 @@ const matterNow = require('..');
 
 program
   .usage('[options] <file...>')
+  .option('-a, --attr <attribute>', 'front matter attribute', 'date')
   .option('-f, --format <format>', 'Moment.js date format')
   .version(version, '-v, --version')
   .parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -3,17 +3,17 @@ const grayMatter = require('gray-matter');
 const moment = require('moment');
 
 const hasMatter = (matter) => matter.isEmpty || Object.keys(matter.data).length > 0;
-const hasDate = (matter) => 'date' in matter.data;
+const hasAttr = (matter, attr) => attr in matter.data;
 
-module.exports = (files, { format }) => files.forEach((file) => {
+module.exports = (files, { attr, format }) => files.forEach((file) => {
   const matter = grayMatter.read(file, {});
 
-  if (!hasMatter(matter) || hasDate(matter)) {
+  if (!hasMatter(matter) || hasAttr(matter, attr)) {
     return;
   }
 
   const date = moment().format(format);
-  const newMatter = `${matter.matter}\ndate: ${date}`;
+  const newMatter = `${matter.matter}\n${attr}: ${date}`;
   const newData = `---${newMatter}\n---\n${matter.content}`;
 
   fs.writeFileSync(file, newData);


### PR DESCRIPTION
Allow defining which front matter attribute to use via a `-a, --attr` option, with `date` as default.

Closes #2.